### PR TITLE
feat(auth): サインアップ/サインイン応答の統一と /me エンドポイント追加

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,3 +1,4 @@
+# app/controllers/users/registrations_controller.rb
 class Users::RegistrationsController < Devise::RegistrationsController
   respond_to :json
 
@@ -6,20 +7,34 @@ class Users::RegistrationsController < Devise::RegistrationsController
     build_resource(sign_up_params)
 
     if resource.save
-      sign_in(resource_name, resource) # devise-jwt があればトークン付与
-      render json: { user: serialize_user(resource) }, status: :created
+      # セッションを使わず Warden にセット
+      warden.set_user(resource, scope: resource_name, store: false)
+
+      # devise-jwt が発行したトークンを env から取得
+      token = request.env['warden-jwt_auth.token']
+
+      render json: {
+        user: serialize_user(resource),
+        token: token
+      }, status: :created
     else
-      render json: { errors: resource.errors.full_messages }, status: :unprocessable_content
+      render json: { errors: resource.errors.full_messages },
+             status: :unprocessable_entity
     end
   end
 
   private
 
+  def sign_up_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+
   def respond_with(resource, _opts = {})
     if resource.persisted?
       render json: { user: serialize_user(resource) }, status: :ok
     else
-      render json: { errors: resource.errors.full_messages }, status: :unprocessable_content
+      render json: { errors: resource.errors.full_messages },
+             status: :unprocessable_content
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,16 +5,37 @@ class Users::SessionsController < Devise::SessionsController
   def create
     self.resource = warden.authenticate!(auth_options)
     sign_in(resource_name, resource)
-    render json: { user: serialize_user(resource) }, status: :ok
+
+    # devise-jwt が発行したトークンは env に入る
+    token = request.env['warden-jwt_auth.token']
+
+    render json: {
+      user: resource.slice(:id, :email, :name),
+      token: token
+      # 必要なら exp を返す場合はコメントアウトを外して使う（下に参考コードあり）
+      # exp: jwt_exp(token)
+    }, status: :ok
   end
 
   # DELETE /users/sign_out
   def destroy
     sign_out(resource_name)
-    head :no_content
+    render json: { ok: true }, status: :ok
   end
 
   private
+
+  def respond_with(resource, _opts = {})
+    token = request.env['warden-jwt_auth.token']
+    render json: {
+      user: {
+        id: resource.id,
+        email: resource.email,
+        name: resource.name
+      },
+      token: token
+    }, status: :ok
+  end
 
   def respond_with(resource, _opts = {})
     render json: { user: serialize_user(resource) }, status: :ok

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,6 @@
 class Users::SessionsController < Devise::SessionsController
   respond_to :json
+  before_action :authenticate_user!, only: [:me]
 
   # POST /users/sign_in
   def create
@@ -15,6 +16,16 @@ class Users::SessionsController < Devise::SessionsController
       # 必要なら exp を返す場合はコメントアウトを外して使う（下に参考コードあり）
       # exp: jwt_exp(token)
     }, status: :ok
+  end
+
+  def me
+    if current_user
+      render json: {
+        user: { id: current_user.id, name: current_user.name, email: current_user.email }
+      }, status: :ok
+    else
+      render json: { error: 'Unauthorized' }, status: :unauthorized
+    end
   end
 
   # DELETE /users/sign_out

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,14 +7,15 @@ class Users::SessionsController < Devise::SessionsController
     self.resource = warden.authenticate!(auth_options)
     sign_in(resource_name, resource)
 
-    # devise-jwt が発行したトークンは env に入る
     token = request.env['warden-jwt_auth.token']
 
     render json: {
-      user: resource.slice(:id, :email, :name),
+      user: {
+        id: resource.id,
+        name: resource.name,
+        email: resource.email
+      },
       token: token
-      # 必要なら exp を返す場合はコメントアウトを外して使う（下に参考コードあり）
-      # exp: jwt_exp(token)
     }, status: :ok
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -311,22 +311,22 @@ Devise.setup do |config|
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
   # Rails の secret_key_base を利用
-  config.jwt do |jwt|
-    jwt.secret = Rails.application.secret_key_base
-    # ログイン・ログアウトでトークン発行/無効化するエンドポイントを宣言
-    jwt.dispatch_requests = [
-      ['POST', %r{^/auth/sign_in$}],
-      ['POST', %r{^/auth/sign_up$}]
-    ]
-    jwt.revocation_requests = [
-      ['DELETE', %r{^/auth/sign_out$}]
-    ]
-    jwt.expiration_time = 1.day.to_i
-    jwt.request_formats = {
-      user: [:json] # APIモードで JSON を想定
-    }
-  end
+
 
   # APIサーバなので navigational formats を空に（HTML redirect を防ぐ）
   config.navigational_formats = []
+  # JWT の設定
+  config.jwt do |jwt|
+    jwt.secret = Rails.application.secret_key_base
+    # ここを /users に合わせる
+    jwt.dispatch_requests = [
+      ['POST', %r{^/users/sign_in$}],
+      ['POST', %r{^/users$}]          # Deviseのsign_upは POST /users
+    ]
+    jwt.revocation_requests = [
+      ['DELETE', %r{^/users/sign_out$}]
+    ]
+    jwt.expiration_time = 1.day.to_i
+    jwt.request_formats = { user: [:json] }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
     sessions: 'users/sessions'
   }
 
+  devise_scope :user do
+    get '/me', to: 'users/sessions#me'
+  end
+
   namespace :api do
     namespace :v1 do
       # 例: 現在ユーザー用エンドポイントをこのあと実装予定

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,16 @@
 Rails.application.routes.draw do
-  devise_for :users,
-             defaults: { format: :json },
-             controllers: {
-               registrations: "users/registrations",
-               sessions: "users/sessions"
-             }
+  # 例: /health は現状のまま
+  get :health, to: 'health#show'
+
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
+  }
+
+  namespace :api do
+    namespace :v1 do
+      # 例: 現在ユーザー用エンドポイントをこのあと実装予定
+      # get 'users/me', to: 'users#me'
+    end
+  end
 end


### PR DESCRIPTION
## 説明
### 目的
- サインアップ (`POST /users`) とサインイン (`POST /users/sign_in`) のレスポンス形式を統一し、両方で `{ user, token }` を返すようにする  
- 現在ログイン中のユーザーを取得できる `/me` エンドポイントを追加  

### 変更内容
- **サインアップ**
  - ユーザー作成後に `sign_in` を実行し JWT を発行
  - `request.env['warden-jwt_auth.token']` からトークンを取得して JSON に同梱  
- **サインイン**
  - `SessionsController#create` をオーバーライドし、成功時に `{ user, token }` を返却  
- **/me エンドポイント**
  - Authorization ヘッダーから JWT を検証し、現在のユーザー情報を返す  
- **設定**
  - `jwt.dispatch_requests` に `POST /users` を追加（サインアップ時もトークン発行）
  - `config.navigational_formats = []` により API 専用挙動に  

### 動作確認
#### サインアップ
```sh
EMAIL="signup+$(date +%s)@example.com"
curl -sS -X POST http://localhost:3001/users \
  -H "Content-Type: application/json" \
  -d "{\"user\":{\"name\":\"SignupUser\",\"email\":\"$EMAIL\",\"password\":\"password\",\"password_confirmation\":\"password\"}}" | jq .
```
### 動作確認
#### サインアップ
```sh
EMAIL="signup+$(date +%s)@example.com"
curl -sS -X POST http://localhost:3001/users \
  -H "Content-Type: application/json" \
  -d "{\"user\":{\"name\":\"SignupUser\",\"email\":\"$EMAIL\",\"password\":\"password\",\"password_confirmation\":\"password\"}}" | jq .
```
#### サインイン
```sh
curl -sS -X POST http://localhost:3001/users/sign_in \
  -H "Content-Type: application/json" \
  -d "{\"user\":{\"email\":\"$EMAIL\",\"password\":\"password\"}}" | jq .
```
#### /me
```sh
TOKEN="<上で得た token>"
curl -sS http://localhost:3001/me -H "Authorization: Bearer $TOKEN" | jq .
```

### 今回含まれるコミット
- feat(api): サインイン応答に JWT トークンを JSON として同梱
- feat(auth): サインアップ時にJWTを返却し /me エンドポイントを実装
- feat(auth): /users と /users/sign_in のレスポンスを user + token 形式で統一

