### PR TITLE
fix: /me の認証ガードを強化（未サインイン時は 401 を返却）

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -50,8 +50,17 @@ class Users::SessionsController < Devise::SessionsController
 
   # GET /me
   def me
-    # authenticate_user! 済みのため current_user は存在する想定
-    render json: { user: serialize_user(current_user) }, status: :ok
+    user = current_user || (defined?(warden) ? warden.user(scope: resource_name) : nil)
+    unless user
+      return render_problem(
+        status: 401,
+        code:   "unauthorized",
+        title:  "Unauthorized",
+        detail: "User is not signed in"
+      )
+    end
+
+    render json: { user: serialize_user(user) }, status: :ok
   end
 
   # DELETE /users/sign_out


### PR DESCRIPTION
## 📋 概要
`/me` エンドポイントにおいて、未サインイン状態でアクセスされた際の挙動を改善しました。  
`current_user` が取得できない場合でも、`warden.user(scope: resource_name)` にフォールバックしてユーザーを確認し、  
それでも認証情報が存在しない場合には、`401 Unauthorized` を返すようにしています。

---

## 🔍 変更内容
- `current_user` が `nil` の場合に `warden.user(scope: resource_name)` でフォールバック  
- ユーザーが特定できない場合に `render_problem` で `401 Unauthorized` を返却  
- 正常時は `serialize_user(user)` に統一してレスポンスを返却  

---

## 🧪 確認項目
- [x] サインイン済みのユーザーが `/me` にアクセス → 正常にユーザー情報を返却  
- [x] 未サインイン状態で `/me` にアクセス → `401 Unauthorized` が返却されることを確認  
- [x] warden が有効な環境で正しくユーザー情報を解決できることを確認  

---

## 🧩 関連Issue
- Close #（該当するIssue番号があれば記入）

---

## 💬 備考
- Devise + JWT 認証環境におけるセッション有効判定の曖昧さを解消するための修正です。  
- 今後、フロントエンド側の `/api/me` 呼び出し時にも 401 ハンドリングを統一予定です。

---

👀 **Reviewers**  
@Tomoe @Shion @Maetaku
